### PR TITLE
Update organizers.json

### DIFF
--- a/src/data/organizers.json
+++ b/src/data/organizers.json
@@ -80,12 +80,12 @@
         "imageUrl": "/images/andre-van-den-berg.jpg",
         "socials": [
             {
-                "icon": "fa-linkedin",
-                "url": "https://www.linkedin.com/in/aavdberg/"
-            },
-            {
                 "icon": "fa-twitter",
                 "url": "https://x.com/aavdberg"
+            },
+            {
+                "icon": "fa-linkedin",
+                "url": "https://www.linkedin.com/in/aavdberg/"
             }
         ]
     }


### PR DESCRIPTION
This pull request includes a minor update to the `src/data/organizers.json` file. The change reorders the social media links for an organizer, placing the LinkedIn link after the Twitter link instead of before it.Change order of social icons and link